### PR TITLE
Error in gradient Section 6.1.2?

### DIFF
--- a/topofeatures/topofeatures.tex
+++ b/topofeatures/topofeatures.tex
@@ -119,7 +119,7 @@ and the aspect as:
   \tan \theta = \frac{\frac{\partial z}{\partial x}}{\frac{\partial z}{\partial y}}
 \]
 
-For the case in Figure~\ref{fig:slope_grid}, the aspect would be 195\degree\ and the gradient would be 45\degree.
+For the case in Figure~\ref{fig:slope_grid}, the aspect would be 195\degree\ and the gradient would be 39.5\degree.
 
 
 %%%


### PR DESCRIPTION
I get 39.5 degrees instead of 45 degrees for the example with figure 6.3.
```
from math import *
degrees(atan(sqrt(pow(1/5,2)+pow(4/5,2))))
```