### PR TITLE
Update interpol.tex

### DIFF
--- a/interpol/interpol.tex
+++ b/interpol/interpol.tex
@@ -264,7 +264,7 @@ In practice, one would need to first compute the DT, and then take each edge (an
 \labfig{fig:li}
 \end{marginfigure}
 The linear interpolation in a triangle can be efficiently implemented by using barycentric coordinates, which are local coordinates defined within a triangle.
-Referring to \reffig{fig:li}, any point $x$ inside a triangle $p_1p_2p_3$ can be represented as a linear combination of the 3 vertices:
+Referring to \reffig{fig:li}, any point $x$ inside a triangle $p_0p_1p_2$ can be represented as a linear combination of the 3 vertices:
 \begin{equation}
   x = w_0p_0 + w_1p_1 + w_2p_2
 \end{equation}
@@ -272,7 +272,7 @@ and
 \begin{equation}
   w_0 + w_1 + w_2 = 1   
 \end{equation}
-The coefficients $w_i$ are the barycentric coordinates of the point $x$ with respect to the triangle $p_1p_2p_3$.
+The coefficients $w_i$ are the barycentric coordinates of the point $x$ with respect to the triangle $p_0p_1p_2$.
 Finding the coefficients $w_0$, $w_1$, and $w_2$ can be done by solving a system of linear equations.
 If we subtract $p_2$ from $x$, and we use $w_2 = 1 - w_0 - w_1$, we obtain
 \begin{equation}


### PR DESCRIPTION
The triangle for barycentric coordinates was named p1p2p3, but is referred to as p0p1p2 in the equations and figure